### PR TITLE
Move the cache and checkpoints to "scratch" on the cluster

### DIFF
--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -5,6 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # If you want you can also add it to your ~/.bashrc
 module load gcc/6.3.0 python_gpu/3.8.5 hdf5/1.10.1 eth_proxy
 
+# Set the cache directory to /cluster/scratch
+PIP_CACHE_DIR=/cluster/scratch/$(whoami)/.cache/.pip
+export PIP_CACHE_DIR
+
+# Create virtual environment
 python -m venv "${SCRIPT_DIR}"/venv
 
 # If you want you can also add it to your ~/.bashrc

--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 module load gcc/6.3.0 python_gpu/3.8.5 hdf5/1.10.1 eth_proxy
 
 # Set the cache directory to /cluster/scratch
-PIP_CACHE_DIR=/cluster/scratch/$(whoami)/.cache/.pip
+PIP_CACHE_DIR=$SCRATCH/.cache/.pip
 export PIP_CACHE_DIR
 
 # Create virtual environment

--- a/src/configs/bertweet.json
+++ b/src/configs/bertweet.json
@@ -6,7 +6,7 @@
     "fast_tokenizer": false,
     "args": {
         "epochs": 10,
-        "batch_size": 384,
+        "batch_size": 256,
         "adafactor": false,
         "warmup_steps": 100,
         "weight_decay": 0.0001,

--- a/src/experimentConfigs/experiment.py
+++ b/src/experimentConfigs/experiment.py
@@ -244,7 +244,7 @@ def main(args: list):
     """
     # Set the cache directory to /cluster/scratch if running on the cluster
     if pathlib.Path().resolve().parts[1] == 'cluster':
-        os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '/.cache/huggingface/')
+        os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '.cache/huggingface/')
 
     argv = {a.split('=')[0]: a.split('=')[1] for a in args[1:]}
     testPath = argv.get('test_path', None)

--- a/src/experimentConfigs/experiment.py
+++ b/src/experimentConfigs/experiment.py
@@ -6,6 +6,8 @@ import json
 import os
 import sys
 from typing import Tuple
+import getpass
+import pathlib
 
 import hyperopt
 import hyperopt.pyll
@@ -241,6 +243,10 @@ def main(args: list):
     Args:
         args (list): a dictionary containing the program arguments (sys.argv)
     """
+    # Set the cache directory to /cluster/scratch if running on the cluster
+    if pathlib.Path().resolve().parts[1] == 'cluster':
+        os.environ["TRANSFORMERS_CACHE"] = os.path.join('/cluster/scratch/', getpass.getuser(), '/.cache/huggingface/')
+
     argv = {a.split('=')[0]: a.split('=')[1] for a in args[1:]}
     testPath = argv.get('test_path', None)
     reportPath = argv.get('report_path', './report.json')

--- a/src/experimentConfigs/experiment.py
+++ b/src/experimentConfigs/experiment.py
@@ -6,7 +6,6 @@ import json
 import os
 import sys
 from typing import Tuple
-import getpass
 import pathlib
 
 import hyperopt
@@ -245,7 +244,7 @@ def main(args: list):
     """
     # Set the cache directory to /cluster/scratch if running on the cluster
     if pathlib.Path().resolve().parts[1] == 'cluster':
-        os.environ["TRANSFORMERS_CACHE"] = os.path.join('/cluster/scratch/', getpass.getuser(), '/.cache/huggingface/')
+        os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '/.cache/huggingface/')
 
     argv = {a.split('=')[0]: a.split('=')[1] for a in args[1:]}
     testPath = argv.get('test_path', None)

--- a/src/models/transformersModel.py
+++ b/src/models/transformersModel.py
@@ -189,7 +189,8 @@ class TransformersModel(ModelConstruction):
             output_dir=training_logging_dir,
             **trainer_config_copy
         )
-
+        logger.debug(f"The program is running from: {str(pathlib.Path().resolve())}")
+        logger.debug(f"The checkpoints will be saved in {training_logging_dir}")
         self.trainer = Trainer(
             model=self.model,
             args=training_args,

--- a/src/models/transformersModel.py
+++ b/src/models/transformersModel.py
@@ -118,9 +118,12 @@ class TransformersModel(ModelConstruction):
             _config.update(model_config_dict)
         if pathlib.Path().resolve().parts[1] == 'cluster':
             if os.getenv("TRANSFORMERS_CACHE") is None:
-                os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '/.cache/huggingface/')
+                cache_dir = os.path.join(os.getenv("SCRATCH"), '.cache/huggingface/')
+            else:
+                cache_dir = os.getenv("TRANSFORMERS_CACHE")
             model = AutoModelForSequenceClassification.from_pretrained(self._modelName, config=_config,
-                                                                       proxies={'http': 'proxy.ethz.ch:3128'})
+                                                                       proxies={'http': 'proxy.ethz.ch:3128'},
+                                                                       cache_dir=cache_dir)
         else:
             model = AutoModelForSequenceClassification.from_pretrained(self._modelName, config=_config)
         return model

--- a/src/models/transformersModel.py
+++ b/src/models/transformersModel.py
@@ -3,7 +3,6 @@ import time
 import typing
 import pathlib
 from pathlib import Path
-import getpass
 
 import numpy as np
 import transformers
@@ -80,8 +79,7 @@ class TransformersModel(ModelConstruction):
         self.training_saving_path = Path(self.project_directory, saving_relative_path)
 
         if pathlib.Path().resolve().parts[1] == 'cluster':
-            self.training_saving_path_cluster = Path('/cluster/scratch', getpass.getuser(),
-                                                     self.training_saving_path)
+            self.training_saving_path_cluster = Path(os.getenv("SCRATCH"), 'cil-project', saving_relative_path)
 
     def loadData(self, ratio='sub'):
         self.pipeLine.loadData(ratio)
@@ -187,12 +185,8 @@ class TransformersModel(ModelConstruction):
         else:
             training_logging_dir = self.training_saving_path
 
-        if pathlib.Path().resolve().parts[1] == 'cluster':
-            checkpoints_dir = self.training_saving_path_cluster
-        else:
-            checkpoints_dir = self.training_saving_path
         training_args = TrainingArguments(
-            output_dir=checkpoints_dir,
+            output_dir=training_logging_dir,
             **trainer_config_copy
         )
 

--- a/src/models/transformersModel.py
+++ b/src/models/transformersModel.py
@@ -118,7 +118,7 @@ class TransformersModel(ModelConstruction):
             _config.update(model_config_dict)
         if pathlib.Path().resolve().parts[1] == 'cluster':
             if os.getenv("TRANSFORMERS_CACHE") is None:
-                os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '/.cache/huggingface/')
+                os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '.cache/huggingface/')
             model = AutoModelForSequenceClassification.from_pretrained(self._modelName, config=_config,
                                                                        proxies={'http': 'proxy.ethz.ch:3128'})
         else:

--- a/src/models/transformersModel.py
+++ b/src/models/transformersModel.py
@@ -171,7 +171,6 @@ class TransformersModel(ModelConstruction):
                                                    early_stopping_threshold=early_stopping_threshold))
 
         training_args = TrainingArguments(
-            logging_dir=Path(self.training_saving_path, 'logs'),
             output_dir=Path(self.training_saving_path),
             **trainer_config_copy
         )

--- a/src/preprocessing/pretrainedTransformersPipeline.py
+++ b/src/preprocessing/pretrainedTransformersPipeline.py
@@ -1,3 +1,4 @@
+import os
 import re
 import random
 import pathlib
@@ -99,6 +100,8 @@ class PretrainedTransformersPipeLine(InputPipeline):
             fast_tokenizer = False
 
         if pathlib.Path().resolve().parts[1] == 'cluster':
+            if os.getenv("TRANSFORMERS_CACHE") is None:
+                os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '/.cache/huggingface/')
             self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=fast_tokenizer,
                                                            proxies={'http': 'proxy.ethz.ch:3128'})
         else:

--- a/src/preprocessing/pretrainedTransformersPipeline.py
+++ b/src/preprocessing/pretrainedTransformersPipeline.py
@@ -101,7 +101,7 @@ class PretrainedTransformersPipeLine(InputPipeline):
 
         if pathlib.Path().resolve().parts[1] == 'cluster':
             if os.getenv("TRANSFORMERS_CACHE") is None:
-                os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '/.cache/huggingface/')
+                os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '.cache/huggingface/')
             self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=fast_tokenizer,
                                                            proxies={'http': 'proxy.ethz.ch:3128'})
         else:

--- a/src/preprocessing/pretrainedTransformersPipeline.py
+++ b/src/preprocessing/pretrainedTransformersPipeline.py
@@ -101,9 +101,12 @@ class PretrainedTransformersPipeLine(InputPipeline):
 
         if pathlib.Path().resolve().parts[1] == 'cluster':
             if os.getenv("TRANSFORMERS_CACHE") is None:
-                os.environ["TRANSFORMERS_CACHE"] = os.path.join(os.getenv("SCRATCH"), '/.cache/huggingface/')
+                cache_dir = os.path.join(os.getenv("SCRATCH"), '.cache/huggingface/')
+            else:
+                cache_dir = os.getenv("TRANSFORMERS_CACHE")
             self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=fast_tokenizer,
-                                                           proxies={'http': 'proxy.ethz.ch:3128'})
+                                                           proxies={'http': 'proxy.ethz.ch:3128'},
+                                                           cache_dir=cache_dir)
         else:
             self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=fast_tokenizer)
         self._dataLoaded = False


### PR DESCRIPTION
When running on the cluster:

- pip cache -> $SCRATCH/.cache/.pip/
- transformers cache -> $SCRATCH/.cache/huggingface/
- tranining checkpoints -> $SCRATCH/cil-project/trainings/MODEL_NAME/TIME_STAMP

As they use too much space on the cluster and will easily exceed the storage quota.